### PR TITLE
Add support for connecting to HTTPS servers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,11 @@ include = [
 hyper = { version = "0.14", features = ["full"] }
 lazy_static = "1.4"
 unicase = "2.6"
+hyper-tls = { version = "0.5", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+
+[features]
+https = ["hyper-tls"]
+default = ["https"]


### PR DESCRIPTION
 * Add the `https` feature which condionally compiles the `hyper-tls` crate
 * Abstract HTTP(S) client building to a helper function with two versions: One which uses the `hyper-tls` `HttpsConnector` connector, and one which uses the default built-in `HttpConnector`
 * Update documentation on how to enable HTTPS support