### PR TITLE
port lib to hyper 0.13 and future 0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+/.idea
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ include = [
 
 [dependencies]
 hyper = "0.13"
-futures = "0.3"
 lazy_static = "1.4"
 unicase = "2.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyper-reverse-proxy"
-version = "0.4.0"
-authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>", "Felipe Noronha <felipenoris@gmail.com>"]
+version = "0.5.0"
+authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>", "Felipe Noronha <felipenoris@gmail.com>", "Jan Kantert <jan-hyper-reverse-proxy@kantert.net>"]
 license = "Apache-2.0"
 description = "A simple reverse proxy, to be used with Hyper and Tokio."
 homepage = "https://github.com/felipenoris/hyper-reverse-proxy"
@@ -19,7 +19,10 @@ include = [
 ]
 
 [dependencies]
-hyper = "0.12"
-futures = "0.1"
-lazy_static = "1.3"
-unicase = "2.3"
+hyper = "0.13"
+futures = "0.3"
+lazy_static = "1.4"
+unicase = "2.6"
+
+[dev-dependencies]
+tokio = { version = "0.2", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@
 //! [dependencies]
 //! hyper-reverse-proxy = "0.5"
 //! hyper = "0.13"
-//! futures = "0.3"
 //! tokio = { version = "0.2", features = ["full"] }
 //! ```
 //!
@@ -36,7 +35,6 @@
 //! use hyper::server::conn::AddrStream;
 //! use hyper::{Body, Request, Response, Server, StatusCode};
 //! use hyper::service::{service_fn, make_service_fn};
-//! use futures::future::{self, Future};
 //! use std::{convert::Infallible, net::SocketAddr};
 //! use hyper::http::uri::InvalidUri;
 //! use std::net::IpAddr;


### PR DESCRIPTION
I ported this library to hyper 0.13 with future 0.3. Additionally, I changed the Result to return ProxyError instead of panicing which is easy to trigger at runtime with broken URLs. I remove all unwrap in the lib and return the internal server error in the example instead.

fixes #8 