### PR TITLE
Update to hyper 0.14 and tokio 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-reverse-proxy"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>", "Felipe Noronha <felipenoris@gmail.com>", "Jan Kantert <jan-hyper-reverse-proxy@kantert.net>"]
 license = "Apache-2.0"
 description = "A simple reverse proxy, to be used with Hyper and Tokio."
@@ -19,9 +19,10 @@ include = [
 ]
 
 [dependencies]
-hyper = "0.13"
+hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp" ] }
 lazy_static = "1.4"
 unicase = "2.6"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["full"] }
+hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp", "server" ] }
+tokio = { version = "1", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,9 @@
 //!
 //! ```toml
 //! [dependencies]
-//! hyper-reverse-proxy = "0.5"
-//! hyper = "0.13"
-//! tokio = { version = "0.2", features = ["full"] }
+//! hyper-reverse-proxy = "0.6"
+//! hyper = "0.14"
+//! tokio = { version = "1.0", features = ["full"] }
 //! ```
 //!
 //! The following example will set up a reverse proxy listening on `127.0.0.1:13900`,
@@ -32,8 +32,8 @@
 //! * All other URLs will be handled by `debug_request` function, that will display request information.
 //!
 //! ```rust,no_run
-//! use hyper::server::conn::AddrStream;
-//! use hyper::{Body, Request, Response, Server, StatusCode};
+//! use hyper::server::{Server, conn::AddrStream};
+//! use hyper::{Body, Request, Response, StatusCode};
 //! use hyper::service::{service_fn, make_service_fn};
 //! use std::{convert::Infallible, net::SocketAddr};
 //! use hyper::http::uri::InvalidUri;
@@ -92,10 +92,11 @@
 //! ```
 //!
 
+use hyper::client::Client;
 use hyper::header::{HeaderMap, HeaderValue};
 use hyper::http::header::{InvalidHeaderValue, ToStrError};
 use hyper::http::uri::InvalidUri;
-use hyper::{Body, Client, Error, Request, Response, Uri};
+use hyper::{Body, Error, Request, Response, Uri};
 use lazy_static::lazy_static;
 use std::net::IpAddr;
 use std::str::FromStr;


### PR DESCRIPTION
The code and doc example are both fixed after changing the dependency
versions. Though the public API for hyper-reverse-proxy is unchanged, a
version bump is done since the tokio v1 and v0.3 runtimes are
incompatible.