### PR TITLE
Updates from a few forks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 ]
 
 [dependencies]
-hyper = "0.13"
+hyper-rustls = { version = "^0.22" }
 lazy_static = "1.4"
 unicase = "2.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ include = [
 ]
 
 [dependencies]
+hyper = { version = "^0.14", features = ["full"] }
 hyper-rustls = { version = "^0.22" }
 lazy_static = "1.4"
 unicase = "2.6"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "^1.5", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ use lazy_static::lazy_static;
 use std::net::IpAddr;
 use std::str::FromStr;
 
+#[derive(Debug)]
 pub enum ProxyError {
     InvalidUri(InvalidUri),
     HyperError(Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,9 @@ pub async fn call(
 ) -> Result<Response<Body>, ProxyError> {
     let proxied_request = create_proxied_request(client_ip, &forward_uri, request)?;
 
-    let client = Client::new();
+    let https = hyper_rustls::HttpsConnector::with_native_roots();
+    let client: Client<_, hyper::Body> = Client::builder().build(https);
+
     let response = client.request(proxied_request).await?;
     let proxied_response = create_proxied_response(response);
     Ok(proxied_response)


### PR DESCRIPTION
# Improvements in this PR

1. Draw a few goodies from https://gist.github.com/snoyberg/35a661fff527692d09675ef540c7c1eb, giving the library:
    - HTTPS support using hyper-rustls ✔️

1. Fork items from https://github.com/lazywalker/hyper-reverse-proxy/commits/master, which cover:
    - move to hyper-0.14 ✔️
    - Debug implement for ProxyError ✔️

1. Fork items from https://github.com/Nemo157/hyper-reverse-proxy/commits/tokio-1.0, which cover:
    - tokio v1 support ✔️

1. Ability to drop path substring (❌ in daramir-mod branch)