### PR TITLE
test: add basic parallel unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ unicase = "2.6"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+futures = "0.3"
+async-trait = "0.1"
+tokio-test = "0.4.2"
+test-context = "0.1.3"
+tokiotest-httpserver = "0.2.0"

--- a/tests/test_http.rs
+++ b/tests/test_http.rs
@@ -1,0 +1,82 @@
+use tokio::sync::oneshot::Sender;
+use tokio::task::JoinHandle;
+use hyper::service::{make_service_fn, service_fn};
+use hyper::server::conn::AddrStream;
+use std::convert::Infallible;
+use hyper::{Uri, Client, Request, Body, Server, Response, StatusCode};
+use tokiotest_httpserver::{HttpTestContext, take_port};
+use test_context::AsyncTestContext;
+use test_context::test_context;
+use std::net::{IpAddr, SocketAddr};
+use tokiotest_httpserver::handler::HandlerBuilder;
+
+struct ProxyTestContext {
+    sender: Sender<()>,
+    proxy_handler: JoinHandle<Result<(), hyper::Error>>,
+    http_back: HttpTestContext,
+    port: u16
+}
+
+#[test_context(ProxyTestContext)]
+#[tokio::test]
+async fn test_get_error_500(ctx: &mut ProxyTestContext) {
+    let resp = Client::new().get(ctx.uri("/500")).await.unwrap();
+    assert_eq!(500, resp.status());
+}
+
+#[test_context(ProxyTestContext)]
+#[tokio::test]
+async fn test_get(ctx: &mut ProxyTestContext) {
+    ctx.http_back.add(HandlerBuilder::new("/foo").status_code(StatusCode::OK).build());
+    let resp = Client::new().get(ctx.uri("/foo")).await.unwrap();
+    assert_eq!(200, resp.status());
+}
+
+async fn handle(client_ip: IpAddr, req: Request<Body>, backend_port: u16)  -> Result<Response<Body>, Infallible>  {
+    match hyper_reverse_proxy::call(client_ip,
+                                    format!("http://127.0.0.1:{}", backend_port).as_str(),
+                                    req).await {
+        Ok(response) => {Ok(response)}
+        Err(_) => {Ok(Response::builder()
+                              .status(502)
+                              .body(Body::empty())
+                              .unwrap())}
+    }
+}
+
+
+#[async_trait::async_trait]
+impl AsyncTestContext for ProxyTestContext {
+    async fn setup() -> ProxyTestContext {
+        let http_back: HttpTestContext = AsyncTestContext::setup().await;
+        let (sender, receiver) = tokio::sync::oneshot::channel::<()>();
+        let bp_to_move = http_back.port;
+        let make_svc = make_service_fn(move |conn: &AddrStream| {
+            let remote_addr = conn.remote_addr().ip();
+            let back_port = bp_to_move;
+            async move {
+                Ok::<_, Infallible>(service_fn(move |req| handle(remote_addr, req, back_port)))
+            }
+        });
+        let port = take_port();
+        let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), port);
+        let server = Server::bind(&addr).serve(make_svc).with_graceful_shutdown(async { receiver.await.ok(); });
+        let proxy_handler = tokio::spawn(server);
+        ProxyTestContext {
+            sender,
+            proxy_handler,
+            http_back,
+            port
+        }
+    }
+    async fn teardown(self) {
+        let _ = AsyncTestContext::teardown(self.http_back);
+        let _ = self.sender.send(()).unwrap();
+        let _ = tokio::join!(self.proxy_handler);
+    }
+}
+impl ProxyTestContext {
+    pub fn uri(&self, path: &str) -> Uri {
+        format!("http://{}:{}{}", "localhost", self.port, path).parse::<Uri>().unwrap()
+    }
+}


### PR DESCRIPTION

This PR adds http integration tests for the proxy.

It runs parallel with a port allocated for the server and one for the proxy for each test. For example you could see with ngrep 

```
$ sudo ngrep -d lo
###########                                                                                                                                                                                                 [2/543]
T 127.0.0.1:58094 -> 127.0.0.1:12397 [AP] #151                                                                                                                                                                     
  GET /500 HTTP/1.1..host: localhost:12397....                                                                                                                                                                     
#                                                                                                                                                                                                                  
T 127.0.0.1:55480 -> 127.0.0.1:12396 [AP] #152                                                                                                                                                                     
  GET /foo HTTP/1.1..host: localhost:12396....                                                                                                                                                                     
#########                                                                                                                                                                                                          
T 127.0.0.1:39576 -> 127.0.0.1:12399 [AP] #161                                                                                                                                                                     
  GET /500 HTTP/1.1..host: localhost:12397..x-forwarded-for: 127.0.0.1....                                                                                                                                         
#                                                                                                                                                                                                                  
T 127.0.0.1:56454 -> 127.0.0.1:12398 [AP] #162                                                                                                                                                                     
  GET /foo HTTP/1.1..host: localhost:12396..x-forwarded-for: 127.0.0.1....                                                                                                                                         
###                                                                                                                                                                                                                
T 127.0.0.1:12399 -> 127.0.0.1:39576 [AP] #165                                                                                                                                                                     
  HTTP/1.1 500 Internal Server Error..content-length: 0..date: Sat, 12 Mar 2022 19:36:37 GMT....                                                                                                                   
##                                                                                                                                                                                                                 
T 127.0.0.1:12398 -> 127.0.0.1:56454 [AP] #167                                                                                                                                                                     
  HTTP/1.1 200 OK..content-length: 0..date: Sat, 12 Mar 2022 19:36:37 GMT....                                                                                                                                      
##                                                                                                                                                                                                                 
T 127.0.0.1:12396 -> 127.0.0.1:55480 [AP] #169                                                                                                                                                                     
  HTTP/1.1 200 OK..date: Sat, 12 Mar 2022 19:36:37 GMT..content-length: 0....                                                                                                                                      
#                                                                                                                                                                                                                  
T 127.0.0.1:12397 -> 127.0.0.1:58094 [AP] #170                                                                                                                                                                     
  HTTP/1.1 500 Internal Server Error..date: Sat, 12 Mar 2022 19:36:37 GMT..content-length: 0....                                                                                                                 
##############
```