### PR TITLE
perf: remove headers inline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,10 +112,11 @@ lazy_static! {
     static ref CONNECTION_HEADER: HeaderName = HeaderName::from_static("connection");
     static ref UPGRADE_HEADER: HeaderName = HeaderName::from_static("upgrade");
     // A list of the headers, using hypers actual HeaderName comparison
-    static ref HOP_HEADERS: [HeaderName; 8] = [
+    static ref HOP_HEADERS: [HeaderName; 9] = [
         CONNECTION_HEADER.clone(),
         TE_HEADER.clone(),
         HeaderName::from_static("keep-alive"),
+        HeaderName::from_static("proxy-connection"),
         HeaderName::from_static("proxy-authenticate"),
         HeaderName::from_static("proxy-authorization"),
         HeaderName::from_static("trailer"),


### PR DESCRIPTION
Well cloing all headers isn't really a huge overhead but again I see it as a performance loss as a) mem neads to be allocated as you clone and insert and b) cycles are spent to iterate over all headers which all iterate over the `HOP_HEADERS` array.

So I know, duplicated code should be eliminated but in case of this I couldn't find another solution and looking at it, 2 times 3 lines of code really aint that much.