### PR TITLE
feat: add basic ci with build, test and bench

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
       - "master"
       - "main"
       - "develop"
-      - "*"
   pull_request:
     branches:
       - "*"
@@ -47,7 +46,7 @@ jobs:
           override: true
 
       - name: Test
-        run: cargo test
+        run: cargo  test-all-features
 
       - name: Bench
         run: cargo bench  --all-features
@@ -91,6 +90,14 @@ jobs:
           toolchain: stable
           override: true
       
+      - name:  Install ssl (linux)
+        if: runner.os == 'Linux'
+        run:  sudo apt update -y && sudo apt upgrade -y && sudo apt install libssl-dev 
+      
+      - name: Install ssl (macOS)
+        if: runner.os == 'macOS'
+        run: brew install openssl
+
       - name: Build Dev
         run: cross build --target ${{ matrix.config.arch }} --lib
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,106 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+      - "main"
+      - "develop"
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build-native:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - node: ubuntu-latest
+          - node: windows-latest
+          - node: macos-latest
+    runs-on: ${{ matrix.config.node }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2.4.0
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1.3.0
+
+      - name: Install tooling
+        run: cargo install cargo-all-features
+
+      - name: Build Dev
+        run: cargo build-all-features
+
+      - name: Build Release
+        run: cargo build-all-features --release
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+
+      - name: Test
+        run: cargo test
+
+      - name: Bench
+        run: cargo bench  --all-features
+
+  build-cross:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # ubuntu aarch64
+          - node: ubuntu-latest
+            arch: aarch64-unknown-linux-gnu
+          - node: ubuntu-latest
+            arch: aarch64-unknown-linux-musl
+
+          # ubuntu x86
+          - node: ubuntu-latest
+            arch: x86_64-unknown-linux-gnu
+          - node: ubuntu-latest
+            arch: x86_64-unknown-linux-musl
+          
+          # apple aarch64
+          - node: macos-latest
+            arch: aarch64-apple-darwin
+
+    runs-on: ${{ matrix.config.node }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2.4.0
+
+      - uses: docker-practice/actions-setup-docker@master
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Install
+        run: cargo install cross
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      
+      - name: Build Dev
+        run: cross build --target ${{ matrix.config.arch }} --lib
+      
+      - name: Build Release
+        run: cross build --target ${{ matrix.config.arch }} --release --lib
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      
+      - name: Test Dev
+        run: cross test --target ${{ matrix.config.arch }}  --lib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 [dependencies]
 hyper = { version = "0.14", features = ["full"] }
 lazy_static = "1.4"
-hyper-tls = { version = "0.5", optional = true }
+hyper-rustls = { version = "0.23.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -32,5 +32,5 @@ test-context = "0.1.3"
 tokiotest-httpserver = "0.2.0"
 
 [features]
-https = ["hyper-tls"]
+https = ["hyper-rustls"]
 default = ["https"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@
 //!
 
 use hyper::client::{connect::dns::GaiResolver, HttpConnector};
-use hyper::header::{HeaderMap, HeaderValue, HeaderName, HOST};
+use hyper::header::{HeaderMap, HeaderName, HeaderValue, HOST};
 use hyper::http::header::{InvalidHeaderValue, ToStrError};
 use hyper::http::uri::InvalidUri;
 use hyper::{Body, Client, Error, Request, Response};
@@ -116,7 +116,7 @@ lazy_static! {
         HeaderName::from_static("transfer-encoding"),
         HeaderName::from_static("upgrade"),
     ];
-    
+
     static ref X_FORWARDED_FOR: HeaderName = HeaderName::from_static("x-forwarded-for");
 }
 
@@ -177,10 +177,10 @@ fn create_proxied_response<B>(mut response: Response<B>, host: HeaderValue) -> R
     response
 }
 
-
 fn forward_uri<B>(forward_url: &str, req: &Request<B>) -> String {
     if let Some(query) = req.uri().query() {
-        let mut forwarding_uri = String::with_capacity(forward_url.len() + req.uri().path().len() + query.len() + 1);
+        let mut forwarding_uri =
+            String::with_capacity(forward_url.len() + req.uri().path().len() + query.len() + 1);
 
         forwarding_uri.push_str(forward_url);
         forwarding_uri.push_str(req.uri().path());
@@ -204,7 +204,7 @@ fn create_proxied_request<B>(
     mut request: Request<B>,
 ) -> Result<Request<B>, ProxyError> {
     let uri: hyper::Uri = forward_uri(forward_url, &request).parse()?;
-    let host = uri.host().map(|e|e.to_owned());
+    let host = uri.host().map(|e| e.to_owned());
 
     *request.headers_mut() = remove_hop_headers(request.headers());
     *request.uri_mut() = uri;
@@ -221,14 +221,20 @@ fn create_proxied_request<B>(
         }
     }
 
-    request.headers_mut().insert(HOST, host.unwrap().parse::<HeaderValue>()?);
+    request
+        .headers_mut()
+        .insert(HOST, host.unwrap().parse::<HeaderValue>()?);
 
     Ok(request)
 }
 
 #[cfg(feature = "https")]
-fn build_client() -> Client<hyper_tls::HttpsConnector<HttpConnector<GaiResolver>>, hyper::Body> {
-    let https = hyper_tls::HttpsConnector::new();
+fn build_client() -> Client<hyper_rustls::HttpsConnector<HttpConnector<GaiResolver>>, hyper::Body> {
+    let https = hyper_rustls::HttpsConnectorBuilder::new()
+        .with_native_roots()
+        .https_only()
+        .enable_http1()
+        .build();
     Client::builder().build::<_, hyper::Body>(https)
 }
 
@@ -242,7 +248,11 @@ pub async fn call(
     forward_uri: &str,
     request: Request<Body>,
 ) -> Result<Response<Body>, ProxyError> {
-    let host = request.headers().get(HOST).unwrap_or(&HeaderValue::from_str("").unwrap()).to_owned();
+    let host = request
+        .headers()
+        .get(HOST)
+        .unwrap_or(&HeaderValue::from_str("").unwrap())
+        .to_owned();
 
     let proxied_request = create_proxied_request(client_ip, forward_uri, request)?;
 


### PR DESCRIPTION
Adds basic CI (not CD).

What it does:
  - Builds, tests and benches on native platforms (windows, macos, linux)
  - Uses `cargo-all-features` to do so on all combinations of features
  - Uses `cross` to build and test for foreign hardware such as aarch64 darwin (M1 macs)