### PR TITLE
feat: connection upgrades

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ hyper = { version = "0.14.18", features = ["server"] }
 tokio = { version = "1.17.0", features = ["full"] }
 futures = "0.3.21"
 async-trait = "0.1.53"
+async-tungstenite = { version = "0.17", features = ["tokio-runtime"] }
 tokio-test = "0.4.2"
 test-context = "0.1.3"
 tokiotest-httpserver = "0.2.1"
@@ -38,3 +39,5 @@ hyper-trust-dns = { version = "0.4.2", features = [
   "rustls-webpki"
 ] }
 rand = "0.8.5"
+tungstenite = "0.17"
+url = "2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ include = ["Cargo.toml", "LICENSE", "src/**/*"]
 [dependencies]
 hyper = { version = "0.14.18", features = ["client"] }
 lazy_static = "1.4.0"
+tokio = { version = "1.17.0", features = ["full"] }
 tracing = "0.1.34"
 
 [dev-dependencies]
 hyper = { version = "0.14.18", features = ["server"] }
-tokio = { version = "1.17.0", features = ["full"] }
 futures = "0.3.21"
 async-trait = "0.1.53"
 async-tungstenite = { version = "0.17", features = ["tokio-runtime"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = ["Cargo.toml", "LICENSE", "src/**/*"]
 [dependencies]
 hyper = { version = "0.14.18", features = ["client"] }
 lazy_static = "1.4.0"
-tokio = { version = "1.17.0", features = ["full"] }
+tokio = { version = "1.17.0", features = ["io-util", "rt"] }
 tracing = "0.1.34"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,6 +412,8 @@ pub async fn call<'a, T: hyper::client::connect::Connect + Clone + Send + Sync +
             .expect("response does not have an upgrade extension")
             .await?;
 
+        debug!("Responding to a connection upgrade response");
+
         tokio::spawn(async move {
             let mut request_upgraded = request_upgraded
                 .expect("request does not have an upgrade extension")
@@ -423,13 +425,13 @@ pub async fn call<'a, T: hyper::client::connect::Connect + Clone + Send + Sync +
                 .expect("coping between upgraded connections failed");
         });
 
-        return Ok(response);
+        Ok(response)
+    } else {
+        let proxied_response = create_proxied_response(response);
+
+        debug!("Responding to call with response");
+        Ok(proxied_response)
     }
-
-    let proxied_response = create_proxied_response(response);
-
-    debug!("Responding to call with response");
-    Ok(proxied_response)
 }
 
 pub struct ReverseProxy<T: hyper::client::connect::Connect + Clone + Send + Sync + 'static> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ fn get_upgrade_type(headers: &HeaderMap) -> Option<String> {
                 .to_str()
                 .unwrap()
                 .split(',')
-                .any(|e| e.to_lowercase() == "upgrade")
+                .any(|e| e.trim().to_lowercase() == "upgrade")
         })
         .unwrap_or(false)
     {

--- a/tests/test_http.rs
+++ b/tests/test_http.rs
@@ -51,7 +51,7 @@ async fn test_get_error_500(ctx: &mut ProxyTestContext) {
 #[tokio::test]
 async fn test_upgrade_mismatch(ctx: &mut ProxyTestContext) {
     ctx.http_back.add(
-        HandlerBuilder::new("/normal")
+        HandlerBuilder::new("/ws")
             .status_code(StatusCode::SWITCHING_PROTOCOLS)
             .build(),
     );
@@ -61,7 +61,7 @@ async fn test_upgrade_mismatch(ctx: &mut ProxyTestContext) {
                 .header(CONNECTION, "Upgrade")
                 .header(UPGRADE, "websocket")
                 .method("GET")
-                .uri(ctx.uri("/normal"))
+                .uri(ctx.uri("/ws"))
                 .body(Body::from(""))
                 .unwrap(),
         )
@@ -74,20 +74,11 @@ async fn test_upgrade_mismatch(ctx: &mut ProxyTestContext) {
 #[tokio::test]
 async fn test_upgrade_unrequested(ctx: &mut ProxyTestContext) {
     ctx.http_back.add(
-        HandlerBuilder::new("/normal")
+        HandlerBuilder::new("/wrong_switch")
             .status_code(StatusCode::SWITCHING_PROTOCOLS)
             .build(),
     );
-    let resp = Client::new()
-        .request(
-            Request::builder()
-                .method("GET")
-                .uri(ctx.uri("/normal"))
-                .body(Body::from(""))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let resp = Client::new().get(ctx.uri("/wrong_switch")).await.unwrap();
     assert_eq!(resp.status(), 502);
 }
 

--- a/tests/test_websocket.rs
+++ b/tests/test_websocket.rs
@@ -1,0 +1,124 @@
+use std::{
+    convert::Infallible,
+    net::{IpAddr, SocketAddr},
+    process::exit,
+    time::Duration,
+};
+
+use async_tungstenite::tokio::{accept_async, connect_async};
+use futures::{SinkExt, StreamExt};
+use hyper::{
+    client::{connect::dns::GaiResolver, HttpConnector},
+    server::conn::AddrStream,
+    service::{make_service_fn, service_fn},
+    Body, Request, Response, Server,
+};
+use hyper_reverse_proxy::ReverseProxy;
+use test_context::{test_context, AsyncTestContext};
+use tokio::{net::TcpListener, sync::oneshot::Sender, task::JoinHandle};
+use tokiotest_httpserver::take_port;
+use tungstenite::Message;
+use url::Url;
+
+lazy_static::lazy_static! {
+    static ref  PROXY_CLIENT: ReverseProxy<HttpConnector<GaiResolver>> = {
+        ReverseProxy::new(
+            hyper::Client::new(),
+        )
+    };
+}
+
+struct ProxyTestContext {
+    sender: Sender<()>,
+    proxy_handler: JoinHandle<Result<(), hyper::Error>>,
+    ws_handler: JoinHandle<()>,
+    port: u16,
+}
+
+#[test_context(ProxyTestContext)]
+#[tokio::test]
+async fn test_websocket(ctx: &mut ProxyTestContext) {
+    println!("making client connection");
+    let (mut client, _) =
+        connect_async(Url::parse(&format!("ws://127.0.0.1:{}", ctx.port)).unwrap())
+            .await
+            .unwrap();
+
+    println!("made client connection");
+    client.send(Message::Ping("ping".into())).await.unwrap();
+    let msg = client.next().await.unwrap().unwrap();
+
+    assert!(matches!(msg, Message::Pong(inner) if inner == "pong".as_bytes()));
+}
+
+async fn handle(
+    client_ip: IpAddr,
+    req: Request<Body>,
+    backend_port: u16,
+) -> Result<Response<Body>, Infallible> {
+    match PROXY_CLIENT
+        .call(
+            client_ip,
+            format!("http://127.0.0.1:{}", backend_port).as_str(),
+            req,
+        )
+        .await
+    {
+        Ok(response) => Ok(response),
+        Err(err) => panic!("did not expect error: {:?}", err),
+    }
+}
+
+#[async_trait::async_trait]
+impl<'a> AsyncTestContext for ProxyTestContext {
+    async fn setup() -> ProxyTestContext {
+        tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            println!("Unit test executed too long, perhaps its stuck...");
+            exit(1);
+        });
+
+        let (sender, receiver) = tokio::sync::oneshot::channel::<()>();
+        let ws_port = take_port();
+
+        let ws_handler = tokio::spawn(async move {
+            let ws_server = TcpListener::bind(("127.0.0.1", ws_port)).await.unwrap();
+
+            while let Ok((stream, addr)) = ws_server.accept().await {
+                println!("incoming connection: {addr}");
+                let mut websocket = accept_async(stream).await.unwrap();
+
+                let msg = websocket.next().await.unwrap().unwrap();
+                assert!(matches!(msg, Message::Ping(inner) if inner == "ping".as_bytes()));
+                println!("past ping");
+
+                websocket.send(Message::Pong("pong".into())).await.unwrap();
+                println!("past pong");
+            }
+        });
+
+        let make_svc = make_service_fn(move |conn: &AddrStream| {
+            let remote_addr = conn.remote_addr().ip();
+            async move { Ok::<_, Infallible>(service_fn(move |req| handle(remote_addr, req, ws_port))) }
+        });
+
+        let port = take_port();
+        let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), port);
+        let server = Server::bind(&addr)
+            .serve(make_svc)
+            .with_graceful_shutdown(async {
+                receiver.await.ok();
+            });
+        let proxy_handler = tokio::spawn(server);
+        ProxyTestContext {
+            sender,
+            proxy_handler,
+            ws_handler,
+            port,
+        }
+    }
+    async fn teardown(self) {
+        let _ = self.sender.send(()).unwrap();
+        let _ = tokio::join!(self.proxy_handler, self.ws_handler);
+    }
+}


### PR DESCRIPTION
The header fixes in #22 (ie restoring the upgrades) make things like WebSocket connections successfully pass through the proxy. However, the responses of the client were still not correct which this PR adds.

Closes #11 