### PR TITLE
Host header is missing the port

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,9 +333,8 @@ fn create_proxied_request<B>(
 
     debug!("Setting headers of proxied request");
 
-    request
-        .headers_mut()
-        .insert(HOST, HeaderValue::from_str(uri.host().unwrap())?);
+    // remove the original HOST header. It will be set by the client that sends the request
+    request.headers_mut().remove(HOST);
 
     *request.uri_mut() = uri;
 


### PR DESCRIPTION
The `host` header that is set by the proxy does not include the port.

The easiest fix is to just remove the `host` header as it will be automatically set by the client when sending the request:
https://github.com/hyperium/hyper/blob/4fcfe1f4ba461209483dec960e36293459a1c60a/src/client/client.rs#L250