### PR TITLE
refactor: make all headers const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ harness = false
 
 [dependencies]
 hyper = { version = "0.14.18", features = ["client"] }
-lazy_static = "1.4.0"
 tokio = { version = "1.17.0", features = ["io-util", "rt"] }
 tracing = "0.1.34"
 
@@ -46,6 +45,7 @@ rand = "0.8.5"
 tungstenite = "0.17"
 url = "2.2"
 criterion = "0.3.5"
+lazy_static = "1.4.0"
 
 [features]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,31 +8,27 @@ use hyper::http::header::{InvalidHeaderValue, ToStrError};
 use hyper::http::uri::InvalidUri;
 use hyper::upgrade::OnUpgrade;
 use hyper::{Body, Client, Error, Request, Response, StatusCode};
-use lazy_static::lazy_static;
 use std::net::IpAddr;
 use tokio::io::copy_bidirectional;
 
-lazy_static! {
-    static ref TE_HEADER: HeaderName = HeaderName::from_static("te");
-    static ref CONNECTION_HEADER: HeaderName = HeaderName::from_static("connection");
-    static ref UPGRADE_HEADER: HeaderName = HeaderName::from_static("upgrade");
-    static ref TRAILER_HEADER: HeaderName = HeaderName::from_static("trailer");
-    static ref TRAILERS_HEADER: HeaderName = HeaderName::from_static("trailers");
-    // A list of the headers, using hypers actual HeaderName comparison
-    static ref HOP_HEADERS: [HeaderName; 9] = [
-        CONNECTION_HEADER.clone(),
-        TE_HEADER.clone(),
-        TRAILER_HEADER.clone(),
-        HeaderName::from_static("keep-alive"),
-        HeaderName::from_static("proxy-connection"),
-        HeaderName::from_static("proxy-authenticate"),
-        HeaderName::from_static("proxy-authorization"),
-        HeaderName::from_static("transfer-encoding"),
-        HeaderName::from_static("upgrade"),
-    ];
+static TE_HEADER: HeaderName = HeaderName::from_static("te");
+static CONNECTION_HEADER: HeaderName = HeaderName::from_static("connection");
+static UPGRADE_HEADER: HeaderName = HeaderName::from_static("upgrade");
+static TRAILERS_HEADER: HeaderName = HeaderName::from_static("trailers");
+// A list of the headers, using hypers actual HeaderName comparison
+static HOP_HEADERS: [HeaderName; 9] = [
+    HeaderName::from_static("connection"),
+    HeaderName::from_static("te"),
+    HeaderName::from_static("trailer"),
+    HeaderName::from_static("keep-alive"),
+    HeaderName::from_static("proxy-connection"),
+    HeaderName::from_static("proxy-authenticate"),
+    HeaderName::from_static("proxy-authorization"),
+    HeaderName::from_static("transfer-encoding"),
+    HeaderName::from_static("upgrade"),
+];
 
-    static ref X_FORWARDED_FOR: HeaderName = HeaderName::from_static("x-forwarded-for");
-}
+const X_FORWARDED_FOR: HeaderName = HeaderName::from_static("x-forwarded-for");
 
 #[derive(Debug)]
 pub enum ProxyError {
@@ -69,7 +65,7 @@ impl From<InvalidHeaderValue> for ProxyError {
 fn remove_hop_headers(headers: &mut HeaderMap) {
     debug!("Removing hop headers");
 
-    for header in &*HOP_HEADERS {
+    for header in &HOP_HEADERS {
         headers.remove(header);
     }
 }
@@ -77,17 +73,17 @@ fn remove_hop_headers(headers: &mut HeaderMap) {
 fn get_upgrade_type(headers: &HeaderMap) -> Option<String> {
     #[allow(clippy::blocks_in_if_conditions)]
     if headers
-        .get(&*CONNECTION_HEADER)
+        .get(&CONNECTION_HEADER)
         .map(|value| {
             value
                 .to_str()
                 .unwrap()
                 .split(',')
-                .any(|e| e.trim() == *UPGRADE_HEADER)
+                .any(|e| e.trim() == UPGRADE_HEADER)
         })
         .unwrap_or(false)
     {
-        if let Some(upgrade_value) = headers.get(&*UPGRADE_HEADER) {
+        if let Some(upgrade_value) = headers.get(&UPGRADE_HEADER) {
             debug!(
                 "Found upgrade header with value: {}",
                 upgrade_value.to_str().unwrap().to_owned()
@@ -101,10 +97,10 @@ fn get_upgrade_type(headers: &HeaderMap) -> Option<String> {
 }
 
 fn remove_connection_headers(headers: &mut HeaderMap) {
-    if headers.get(&*CONNECTION_HEADER).is_some() {
+    if headers.get(&CONNECTION_HEADER).is_some() {
         debug!("Removing connection headers");
 
-        let value = headers.get(&*CONNECTION_HEADER).cloned().unwrap();
+        let value = headers.get(&CONNECTION_HEADER).cloned().unwrap();
 
         for name in value.to_str().unwrap().split(',') {
             if !name.trim().is_empty() {
@@ -211,13 +207,13 @@ fn create_proxied_request<B>(
 
     let contains_te_trailers_value = request
         .headers()
-        .get(&*TE_HEADER)
+        .get(&TE_HEADER)
         .map(|value| {
             value
                 .to_str()
                 .unwrap()
                 .split(',')
-                .any(|e| e.trim() == *TRAILERS_HEADER)
+                .any(|e| e.trim() == TRAILERS_HEADER)
         })
         .unwrap_or(false);
 
@@ -239,7 +235,7 @@ fn create_proxied_request<B>(
 
         request
             .headers_mut()
-            .insert(&*TE_HEADER, HeaderValue::from_static("trailers"));
+            .insert(&TE_HEADER, HeaderValue::from_static("trailers"));
     }
 
     if let Some(value) = upgrade_type {
@@ -247,14 +243,14 @@ fn create_proxied_request<B>(
 
         request
             .headers_mut()
-            .insert(&*UPGRADE_HEADER, value.parse().unwrap());
+            .insert(&UPGRADE_HEADER, value.parse().unwrap());
         request
             .headers_mut()
-            .insert(&*CONNECTION_HEADER, HeaderValue::from_static("UPGRADE"));
+            .insert(&CONNECTION_HEADER, HeaderValue::from_static("UPGRADE"));
     }
 
     // Add forwarding information in the headers
-    match request.headers_mut().entry(&*X_FORWARDED_FOR) {
+    match request.headers_mut().entry(X_FORWARDED_FOR) {
         hyper::header::Entry::Vacant(entry) => {
             debug!("X-Fowraded-for header was vacant");
             entry.insert(client_ip.to_string().parse()?);
@@ -366,7 +362,7 @@ impl<T: hyper::client::connect::Connect + Clone + Send + Sync + 'static> Reverse
 #[cfg(feature = "__bench")]
 pub mod benches {
     pub fn hop_headers() -> &'static [crate::HeaderName] {
-        &*super::HOP_HEADERS
+        super::HOP_HEADERS
     }
 
     pub fn create_proxied_response<T>(response: crate::Response<T>) {


### PR DESCRIPTION
hyper::header::from_static is a **const fn**, we can define our headers in const and remove lazy-static dep(move it to dev-dependency)