### PR TITLE
fix: get upgrade type as lowercase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,20 +23,20 @@ name="internal"
 harness = false
 
 [dependencies]
-hyper = { version = "0.14.20", features = ["client"] }
+hyper = { version = "0.14.20", default-features = false }
 lazy_static = "1.4.0"
-tokio = { version = "1.17.0", features = ["io-util", "rt"] }
-tracing = "0.1.34"
+tokio = { version = "1.17.0", default-features = false }
+tracing = { default-features = false, version = "0.1.34" }
 
 [dev-dependencies]
 hyper = { version = "0.14.18", features = ["server"] }
 futures = "0.3.21"
 async-trait = "0.1.53"
-async-tungstenite = { version = "0.17", features = ["tokio-runtime"] }
+async-tungstenite = { version = "0.18", features = ["tokio-runtime"] }
 tokio-test = "0.4.2"
 test-context = "0.1.3"
 tokiotest-httpserver = "0.2.1"
-hyper-trust-dns = { version = "0.4.2", features = [
+hyper-trust-dns = { version = "0.5.0", features = [
   "rustls-http2",
   "dnssec-ring",
   "dns-over-https-rustls",
@@ -45,7 +45,7 @@ hyper-trust-dns = { version = "0.4.2", features = [
 rand = "0.8.5"
 tungstenite = "0.17"
 url = "2.2"
-criterion = "0.3.5"
+criterion = "0.4"
 
 [features]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name="internal"
 harness = false
 
 [dependencies]
-hyper = { version = "0.14.18", features = ["client"] }
+hyper = { version = "0.14.20", features = ["client"] }
 lazy_static = "1.4.0"
 tokio = { version = "1.17.0", features = ["io-util", "rt"] }
 tracing = "0.1.34"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ fn get_upgrade_type(headers: &HeaderMap) -> Option<String> {
                 upgrade_value.to_str().unwrap().to_owned()
             );
 
-            return Some(upgrade_value.to_str().unwrap().to_owned());
+            return Some(upgrade_value.to_str().unwrap().to_lowercase().to_owned());
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ fn get_upgrade_type(headers: &HeaderMap) -> Option<String> {
                 upgrade_value.to_str().unwrap().to_owned()
             );
 
-            return Some(upgrade_value.to_str().unwrap().to_lowercase().to_owned());
+            return Some(upgrade_value.to_str().unwrap().to_lowercase());
         }
     }
 
@@ -128,7 +128,7 @@ fn forward_uri<B>(forward_url: &str, req: &Request<B>) -> String {
 
     let split_url = forward_url.split('?').collect::<Vec<&str>>();
 
-    let mut base_url: &str = split_url.get(0).unwrap_or(&"");
+    let mut base_url: &str = split_url.first().unwrap_or(&"");
     let forward_url_query: &str = split_url.get(1).unwrap_or(&"");
 
     let path2 = req.uri().path();
@@ -338,9 +338,10 @@ pub async fn call<'a, T: hyper::client::connect::Connect + Clone + Send + Sync +
                     let mut request_upgraded =
                         request_upgraded.await.expect("failed to upgrade request");
 
-                    copy_bidirectional(&mut response_upgraded, &mut request_upgraded)
-                        .await
-                        .expect("coping between upgraded connections failed");
+                    match copy_bidirectional(&mut response_upgraded, &mut request_upgraded).await {
+                        Ok(_) => debug!("successfull copy between upgraded connections"),
+                        Err(_) => error!("failed copy between upgraded connections (EOF)"),
+                    }
                 });
 
                 Ok(response)


### PR DESCRIPTION
fix: get upgrade type as lowercase for cases where request and response are not consistent (ex: ttyd)

Best regards,